### PR TITLE
Add Mock Weather Data and DataModel

### DIFF
--- a/app/sampledata/mockFiveDayForecast
+++ b/app/sampledata/mockFiveDayForecast
@@ -1,0 +1,333 @@
+{
+  "DailyForecasts": [
+    {
+      "Date": "2023-11-25",
+      "Temperature": {
+        "Minimum": {
+          "Value": 32,
+          "Unit": "F"
+        },
+        "Maximum": {
+          "Value": 45,
+          "Unit": "F"
+        }
+      },
+      "AirAndPollen": [
+        {
+          "Name": "UVIndex",
+          "Value": 2,
+          "Category": "Low"
+        },
+        {
+          "Name": "AirQuality",
+          "Value": 30,
+          "Category": "Good"
+        }
+      ],
+      "Day": {
+        "IconPhrase": "Sunny",
+        "HasPrecipitation": false,
+        "PrecipitationProbability": 0,
+        "Wind": {
+          "Speed": {
+            "Value": 10.0,
+            "Unit": "mi/h"
+          }
+        }
+      },
+      "Night": {
+        "IconPhrase": "Clear",
+        "HasPrecipitation": false,
+        "PrecipitationProbability": 0,
+        "Wind": {
+          "Speed": {
+            "Value": 5.0,
+            "Unit": "mi/h"
+          }
+        }
+      }
+    },
+    {
+      "Date": "2023-11-26",
+      "Temperature": {
+        "Minimum": {
+          "Value": 30,
+          "Unit": "F"
+        },
+        "Maximum": {
+          "Value": 50,
+          "Unit": "F"
+        }
+      },
+      "AirAndPollen": [
+        {
+          "Name": "UVIndex",
+          "Value": 1,
+          "Category": "Low"
+        },
+        {
+          "Name": "AirQuality",
+          "Value": 52,
+          "Category": "Moderate"
+        }
+      ],
+      "Day": {
+        "IconPhrase": "Showers",
+        "HasPrecipitation": true,
+        "PrecipitationProbability": 55,
+        "Wind": {
+          "Speed": {
+            "Value": 6.9,
+            "Unit": "mi/h"
+          }
+        }
+      },
+      "Night": {
+        "IconPhrase": "Rain",
+        "HasPrecipitation": true,
+        "PrecipitationProbability": 92,
+        "Wind": {
+          "Speed": {
+            "Value": 4.6,
+            "Unit": "mi/h"
+          }
+        }
+      }
+    },
+    {
+      "Date": "2023-11-27",
+      "Temperature": {
+        "Minimum": {
+          "Value": 40,
+          "Unit": "F"
+        },
+        "Maximum": {
+          "Value": 50,
+          "Unit": "F"
+        }
+      },
+      "AirAndPollen": [
+        {
+          "Name": "UVIndex",
+          "Value": 1,
+          "Category": "Low"
+        },
+        {
+          "Name": "AirQuality",
+          "Value": 53,
+          "Category": "Moderate"
+        }
+      ],
+      "Day": {
+        "IconPhrase": "Cloudy",
+        "HasPrecipitation": true,
+        "PrecipitationProbability": 40,
+        "Wind": {
+          "Speed": {
+            "Value": 5.8,
+            "Unit": "mi/h"
+          }
+        }
+      },
+      "Night": {
+        "IconPhrase": "Intermittent Clouds",
+        "HasPrecipitation": false,
+        "PrecipitationProbability": 15,
+        "Wind": {
+          "Speed": {
+            "Value": 5.0,
+            "Unit": "mi/h"
+          }
+        }
+      }
+    },
+    {
+      "Date": "2023-11-28",
+      "Temperature": {
+        "Minimum": {
+          "Value": 33,
+          "Unit": "F"
+        },
+        "Maximum": {
+          "Value": 49,
+          "Unit": "F"
+        }
+      },
+      "AirAndPollen": [
+        {
+          "Name": "UVIndex",
+          "Value": 2,
+          "Category": "Low"
+        },
+        {
+          "Name": "AirQuality",
+          "Value": 53,
+          "Category": "Moderate"
+        }
+      ],
+      "Day": {
+        "IconPhrase": "Mostly cloudy",
+        "HasPrecipitation": false,
+        "PrecipitationProbability": 12,
+        "Wind": {
+          "Speed": {
+            "Value": 5.8,
+            "Unit": "mi/h"
+          }
+        }
+      },
+      "Night": {
+        "IconPhrase": "Mostly cloudy",
+        "HasPrecipitation": false,
+        "PrecipitationProbability": 8,
+        "Wind": {
+          "Speed": {
+            "Value": 4.6,
+            "Unit": "mi/h"
+          }
+        }
+      }
+    },
+    {
+      "Date": "2023-11-27",
+      "Temperature": {
+        "Minimum": {
+          "Value": 33,
+          "Unit": "F"
+        },
+        "Maximum": {
+          "Value": 48,
+          "Unit": "F"
+        }
+      },
+      "AirAndPollen": [
+        {
+          "Name": "UVIndex",
+          "Value": 2,
+          "Category": "Low"
+        },
+        {
+          "Name": "AirQuality",
+          "Value": 54,
+          "Category": "Moderate"
+        }
+      ],
+      "Day": {
+        "IconPhrase": "Sunny",
+        "HasPrecipitation": false,
+        "PrecipitationProbability": 7,
+        "Wind": {
+          "Speed": {
+            "Value": 5.8,
+            "Unit": "mi/h"
+          }
+        }
+      },
+      "Night": {
+        "IconPhrase": "Mostly clear",
+        "HasPrecipitation": false,
+        "PrecipitationProbability": 7,
+        "Wind": {
+          "Speed": {
+            "Value": 4.6,
+            "Unit": "mi/h"
+          }
+        }
+      }
+    },
+    {
+      "Date": "2023-11-29",
+      "Temperature": {
+        "Minimum": {
+          "Value": 32,
+          "Unit": "F"
+        },
+        "Maximum": {
+          "Value": 45,
+          "Unit": "F"
+        }
+      },
+      "AirAndPollen": [
+        {
+          "Name": "UVIndex",
+          "Value": 2,
+          "Category": "Low"
+        },
+        {
+          "Name": "AirQuality",
+          "Value": 30,
+          "Category": "Good"
+        }
+      ],
+      "Day": {
+        "IconPhrase": "Sunny",
+        "HasPrecipitation": false,
+        "PrecipitationProbability": 0,
+        "Wind": {
+          "Speed": {
+            "Value": 10.0,
+            "Unit": "mi/h"
+          }
+        }
+      },
+      "Night": {
+        "IconPhrase": "Clear",
+        "HasPrecipitation": false,
+        "PrecipitationProbability": 0,
+        "Wind": {
+          "Speed": {
+            "Value": 5.0,
+            "Unit": "mi/h"
+          }
+        }
+      }
+    },
+    {
+      "Date": "2023-11-27",
+      "Temperature": {
+        "Minimum": {
+          "Value": 45,
+          "Unit": "F"
+        },
+        "Maximum": {
+          "Value": 55,
+          "Unit": "F"
+        }
+      },
+      "AirAndPollen": [
+        {
+          "Name": "UVIndex",
+          "Value": 1,
+          "Category": "Low"
+        },
+        {
+          "Name": "AirQuality",
+          "Value": 30,
+          "Category": "Good"
+        }
+      ],
+      "Day": {
+        "IconPhrase": "Sunny",
+        "HasPrecipitation": false,
+        "PrecipitationProbability": 0,
+        "Wind": {
+          "Speed": {
+            "Value": 10.0,
+            "Unit": "mi/h"
+          }
+        }
+      },
+      "Night": {
+        "IconPhrase": "Shower",
+        "HasPrecipitation": true,
+        "PrecipitationProbability": 55,
+        "Wind": {
+          "Speed": {
+            "Value": 6.9,
+            "Unit": "mi/h"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/app/sampledata/mockLocationKey
+++ b/app/sampledata/mockLocationKey
@@ -1,0 +1,11 @@
+{
+    "PrimaryPostalCode": "98004",
+    "AdministrativeArea": {
+        "ID": "WA"
+    },
+    "ParentCity": {
+        "Key": "331424",
+        "LocalizedName": "Bellevue",
+        "EnglishName": "Bellevue"
+    }
+}

--- a/app/src/main/java/com/example/mainactivity/model/ForecastResponse.kt
+++ b/app/src/main/java/com/example/mainactivity/model/ForecastResponse.kt
@@ -1,0 +1,110 @@
+package com.example.mainactivity.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Represents the complete response for a forecast request.
+ * It includes a list of daily forecasts.
+ * This class is used to deserialize the JSON response containing 5-day Weather-related details.
+ *
+ * @property dailyForecasts List of [DailyForecast] detailing the forecast for each day.
+ */
+@JsonClass(generateAdapter = true)
+data class ForecastResponse(
+    @Json(name = "DailyForecasts") val dailyForecasts: List<DailyForecast>
+)
+
+/**
+ * Details the weather forecast for a specific day, including temperature, and conditions for day and night.
+ *
+ * @property date The date of the forecast.
+ * @property temperature Information about the day's temperature range.
+ * @property airAndPollen List of [AirAndPollen] detailing air quality and UV index information.
+ * @property day Forecast details for the daytime.
+ * @property night Forecast details for the nighttime.
+ */
+@JsonClass(generateAdapter = true)
+data class DailyForecast(
+    @Json(name = "Date") val date: String,
+    @Json(name = "Temperature") val temperature: TemperatureInfo,
+    @Json(name = "AirAndPollen") val airAndPollen: List<AirAndPollen>,
+    @Json(name = "Day") val day: DayForecast,
+    @Json(name = "Night") val night: DayForecast,
+)
+
+/**
+ * Contains temperature details including minimum and maximum values.
+ *
+ * @property minimum The minimum temperature for the day.
+ * @property maximum The maximum temperature for the day.
+ */
+@JsonClass(generateAdapter = true)
+data class TemperatureInfo(
+    @Json(name = "Minimum") val minimum: TemperatureValue,
+    @Json(name = "Maximum") val maximum: TemperatureValue
+)
+
+/**
+ * Represents a temperature value.
+ *
+ * @property value The numerical value of the temperature.
+ * @property unit The unit of measurement for the temperature (e.g., Celsius or Fahrenheit).
+ */
+@JsonClass(generateAdapter = true)
+data class TemperatureValue(
+    @Json(name = "Value") val value: Int,
+    @Json(name = "Unit")val unit: String
+)
+
+/**
+ * Details about specific air quality and pollen conditions, such as UV index and air quality index.
+ * Only includes 'AirQuality' and 'UVIndex' data.
+ *
+ * @property name The name of the air or pollen condition (e.g., 'UVIndex' or 'AirQuality').
+ * @property value The measured value of the condition.
+ * @property category The category of the condition (e.g., Low, Moderate).
+ */
+@JsonClass(generateAdapter = true)
+data class AirAndPollen( //  For AirQuality and UVIndex
+    @Json(name = "Name") val name: String,
+    @Json(name = "Value") val value: Int,
+    @Json(name = "Category") val category: String?
+)
+
+/**
+ * Contains forecast details for a specific period (day or night), including weather conditions and wind information.
+ *
+ * @property iconPhrase A phrase describing the weather icon.
+ * @property hasPrecipitation Boolean indicating if there is any precipitation expected.
+ * @property dayPrecipitation Probability of precipitation during the period.
+ */
+@JsonClass(generateAdapter = true)
+data class DayForecast(
+    @Json(name = "IconPhrase") val iconPhrase: String,
+    @Json(name = "HasPrecipitation") val hasPrecipitation: Boolean,
+    @Json(name = "PrecipitationProbability") val dayPrecipitation: Double,
+    @Json(name = "Wind") val wind: Wind
+)
+
+/**
+ * Contains wind speed information.
+ *
+ * @property speed Details of wind speed.
+ */
+@JsonClass(generateAdapter = true)
+data class Wind(
+    @Json(name = "Speed") val speed: Speed
+)
+
+/**
+ * Represents the speed of the wind.
+ *
+ * @property value The value of the wind speed.
+ * @property unit The unit of measurement for wind speed.
+ */
+@JsonClass(generateAdapter = true)
+data class Speed(
+    @Json(name = "Value") val value: Double,
+    @Json(name = "Unit") val unit: String
+)

--- a/app/src/main/java/com/example/mainactivity/model/LocationResponses.kt
+++ b/app/src/main/java/com/example/mainactivity/model/LocationResponses.kt
@@ -1,0 +1,43 @@
+package com.example.mainactivity.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Represents the response structure for a location query based on postal code.
+ * This class is used to deserialize the JSON response containing location-related details.
+ *
+ * @property postalCode The primary postal code associated with the location query.
+ * @property administrativeArea The administrative area details for the location.
+ * @property parentCity Details of the parent city related to the provided postal code.
+ */
+@JsonClass(generateAdapter = true)
+data class LocationResponse(
+    @Json(name = "PrimaryPostalCode") val postalCode: String,
+    @Json(name = "AdministrativeArea") val administrativeArea: AdministrativeArea,
+    @Json(name = "ParentCity") val parentCity: ParentCity
+)
+
+/**
+ * Contains information about the administrative area of a location.
+ * Typically represents data like the state or province.
+ *
+ * @property stateId The identifier of the administrative area (e.g., state abbreviation).
+ */
+@JsonClass(generateAdapter = true)
+data class AdministrativeArea(
+    @Json(name = "ID") val stateId: String
+)
+
+/**
+ * Represents the parent city information for a given location.
+ * Used in the context of a location response.
+ *
+ * @property locationKey A unique key identifying the parent city.
+ * @property cityName The localized name of the parent city.
+ */
+@JsonClass(generateAdapter = true)
+data class ParentCity(
+    @Json(name = "Key") val locationKey: String,
+    @Json(name = "LocalizedName") val cityName: String
+)


### PR DESCRIPTION
Mock weather data will be used for unit tests. Data Models can be found in `LocationResponse` and `ForecastResponse`data class, these two data classes will be used to deserialize back to Kotlin Objects. Read KDoc (Kotlin Doc) for more info.

Fixes https://github.com/NittanyLions42/Viltvodle-VI/issues/15